### PR TITLE
Import from upstream 3.12 branch:

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+python3.12 (3.12.13-0deepin2) UNRELEASED; urgency=medium
+
+  * Import from upstream 3.12 branch:
+    - gh-146211: Reject CR/LF in HTTP tunnel request headers (GH-146212) (cherry picked from commit 05ed7ce7ae9e17c23a04085b2539fe6d6d3cef69)
+    - gh-146083: Upgrade bundled Expat to 2.7.5 (GH-146085) (cherry picked from commit e39d84a37dfc8bcdc0eb4d6f3ce7d5ee829d7f30)
+    - gh-149017: Upgrade bundled Expat to 2.8.0 (GH-149020) (GH-149073) (cherry picked from commit c181c5fa16273f0cc4d7ed20a016e0921f60fdfd)
+    - gh-149486: tarfile.data_filter: validate written link target (GH-149487)
+    - Move dotdot_resolves_early setting to setUpClass
+    - gh-87451: Apply CVE-2021-4189 PASV fix to ftplib.ftpcp() (GH-149648)
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Thu, 21 May 2026 18:16:57 +0800
+
 python3.12 (3.12.13-0deepin1) unstable; urgency=medium
 
   * Python 3.12.13 release.

--- a/debian/patches/0035-gh-146211-Reject-CR-LF-in-HTTP-tunnel-request-header.patch
+++ b/debian/patches/0035-gh-146211-Reject-CR-LF-in-HTTP-tunnel-request-header.patch
@@ -1,0 +1,96 @@
+From: Seth Larson <seth@python.org>
+Date: Fri, 10 Apr 2026 10:21:42 -0500
+Subject: gh-146211: Reject CR/LF in HTTP tunnel request headers (GH-146212)
+ (cherry picked from commit 05ed7ce7ae9e17c23a04085b2539fe6d6d3cef69)
+
+Co-authored-by: Seth Larson <seth@python.org>
+Co-authored-by: Illia Volochii <illia.volochii@gmail.com>
+---
+ Lib/http/client.py       | 11 ++++++++++-
+ Lib/test/test_httplib.py | 45 +++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 55 insertions(+), 1 deletion(-)
+
+diff --git a/Lib/http/client.py b/Lib/http/client.py
+index 70451d6..7db4807 100644
+--- a/Lib/http/client.py
++++ b/Lib/http/client.py
+@@ -972,13 +972,22 @@ class HTTPConnection:
+         return ip
+ 
+     def _tunnel(self):
++        if _contains_disallowed_url_pchar_re.search(self._tunnel_host):
++            raise ValueError('Tunnel host can\'t contain control characters %r'
++                             % (self._tunnel_host,))
+         connect = b"CONNECT %s:%d %s\r\n" % (
+             self._wrap_ipv6(self._tunnel_host.encode("idna")),
+             self._tunnel_port,
+             self._http_vsn_str.encode("ascii"))
+         headers = [connect]
+         for header, value in self._tunnel_headers.items():
+-            headers.append(f"{header}: {value}\r\n".encode("latin-1"))
++            header_bytes = header.encode("latin-1")
++            value_bytes = value.encode("latin-1")
++            if not _is_legal_header_name(header_bytes):
++                raise ValueError('Invalid header name %r' % (header_bytes,))
++            if _is_illegal_header_value(value_bytes):
++                raise ValueError('Invalid header value %r' % (value_bytes,))
++            headers.append(b"%s: %s\r\n" % (header_bytes, value_bytes))
+         headers.append(b"\r\n")
+         # Making a single send() call instead of one per line encourages
+         # the host OS to use a more optimal packet size instead of
+diff --git a/Lib/test/test_httplib.py b/Lib/test/test_httplib.py
+index e46dac0..e027d93 100644
+--- a/Lib/test/test_httplib.py
++++ b/Lib/test/test_httplib.py
+@@ -369,6 +369,51 @@ class HeaderTests(TestCase):
+                 with self.assertRaisesRegex(ValueError, 'Invalid header'):
+                     conn.putheader(name, value)
+ 
++    def test_invalid_tunnel_headers(self):
++        cases = (
++            ('Invalid\r\nName', 'ValidValue'),
++            ('Invalid\rName', 'ValidValue'),
++            ('Invalid\nName', 'ValidValue'),
++            ('\r\nInvalidName', 'ValidValue'),
++            ('\rInvalidName', 'ValidValue'),
++            ('\nInvalidName', 'ValidValue'),
++            (' InvalidName', 'ValidValue'),
++            ('\tInvalidName', 'ValidValue'),
++            ('Invalid:Name', 'ValidValue'),
++            (':InvalidName', 'ValidValue'),
++            ('ValidName', 'Invalid\r\nValue'),
++            ('ValidName', 'Invalid\rValue'),
++            ('ValidName', 'Invalid\nValue'),
++            ('ValidName', 'InvalidValue\r\n'),
++            ('ValidName', 'InvalidValue\r'),
++            ('ValidName', 'InvalidValue\n'),
++        )
++        for name, value in cases:
++            with self.subTest((name, value)):
++                conn = client.HTTPConnection('example.com')
++                conn.set_tunnel('tunnel', headers={
++                    name: value
++                })
++                conn.sock = FakeSocket('')
++                with self.assertRaisesRegex(ValueError, 'Invalid header'):
++                    conn._tunnel()  # Called in .connect()
++
++    def test_invalid_tunnel_host(self):
++        cases = (
++            'invalid\r.host',
++            '\ninvalid.host',
++            'invalid.host\r\n',
++            'invalid.host\x00',
++            'invalid host',
++        )
++        for tunnel_host in cases:
++            with self.subTest(tunnel_host):
++                conn = client.HTTPConnection('example.com')
++                conn.set_tunnel(tunnel_host)
++                conn.sock = FakeSocket('')
++                with self.assertRaisesRegex(ValueError, 'Tunnel host can\'t contain control characters'):
++                    conn._tunnel()  # Called in .connect()
++
+     def test_headers_debuglevel(self):
+         body = (
+             b'HTTP/1.1 200 OK\r\n'

--- a/debian/patches/0036-gh-146083-Upgrade-bundled-Expat-to-2.7.5-GH-146085-c.patch
+++ b/debian/patches/0036-gh-146083-Upgrade-bundled-Expat-to-2.7.5-GH-146085-c.patch
@@ -1,0 +1,331 @@
+From: Stan Ulbrych <89152624+StanFromIreland@users.noreply.github.com>
+Date: Sun, 29 Mar 2026 19:05:14 +0200
+Subject: gh-146083: Upgrade bundled Expat to 2.7.5 (GH-146085) (cherry picked
+ from commit e39d84a37dfc8bcdc0eb4d6f3ce7d5ee829d7f30)
+
+Co-authored-by: Stan Ulbrych <89152624+StanFromIreland@users.noreply.github.com>
+---
+ Misc/sbom.spdx.json            | 32 ++++++++++-----------
+ Modules/expat/expat.h          |  2 +-
+ Modules/expat/expat_external.h |  2 +-
+ Modules/expat/refresh.sh       |  6 ++--
+ Modules/expat/xmlparse.c       | 65 +++++++++++++++++++++++++++++++++++-------
+ Modules/expat/xmlrole.c        |  2 +-
+ Modules/expat/xmltok.c         |  2 +-
+ Modules/expat/xmltok_ns.c      |  2 +-
+ 8 files changed, 78 insertions(+), 35 deletions(-)
+
+diff --git a/Misc/sbom.spdx.json b/Misc/sbom.spdx.json
+index 360b765..5382336 100644
+--- a/Misc/sbom.spdx.json
++++ b/Misc/sbom.spdx.json
+@@ -48,11 +48,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "9bd33bd279c0d7ea37b0f2d7e07c7c53b7053507"
++          "checksumValue": "9dfd09a3be37618cbcea380c2374b2b8f0288f57"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "d20997001462356b5ce3810ebf5256c8205f58462c64f21eb9bf80f8d1822b08"
++          "checksumValue": "26805a0d1a7a6a5cd8ead9cf7f4da29f63f0547a9ad41e80dba4ed9fe1943140"
+         }
+       ],
+       "fileName": "Modules/expat/expat.h"
+@@ -62,11 +62,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "e658ee5d638ab326109282ff09f1541e27fff8c2"
++          "checksumValue": "da0328279276800cc747ea7da23886a3f402ccb3"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "dbe0582b8f8a8140aca97009e8760105ceed9e7df01ea9d8b3fe47cebf2e5b2d"
++          "checksumValue": "15a80e414e9e7c43edba64b1608a77c724387070138693f9e9bcca49c78a2df7"
+         }
+       ],
+       "fileName": "Modules/expat/expat_external.h"
+@@ -174,11 +174,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "7d3d7d72aa56c53fb5b9e10c0e74e161381f0255"
++          "checksumValue": "0c74fbd48dd515c58eeb65b7e71b29da94be4694"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "f4f87aa0268d92f2b8f5e663788bfadd2e926477d0b061ed4463c02ad29a3e25"
++          "checksumValue": "861e7a50ce81f9f16b42d32a9caa4f817d962b274b2929b579511c6f76d348d4"
+         }
+       ],
+       "fileName": "Modules/expat/xmlparse.c"
+@@ -188,11 +188,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "c8769fcb93f00272a6e6ca560be633649c817ff7"
++          "checksumValue": "7cff4d7210f046144f5fa635113f9c26f30fe3d3"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "5b81f0eb0e144b611dbd1bc9e6037075a16bff94f823d57a81eb2a3e4999e91a"
++          "checksumValue": "eaa6c327f9db4a5cec768d0c01927fea212d3ef4d4f970ebc0a98b9f3602784c"
+         }
+       ],
+       "fileName": "Modules/expat/xmlrole.c"
+@@ -216,11 +216,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "63e4766a09e63760c6518670509198f8d638f4ad"
++          "checksumValue": "48b7aa6503302d4157c61a8763629f3236c23502"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "0ad3f915f2748dc91bf4e4b4a50cf40bf2c95769d0eca7e3b293a230d82bb779"
++          "checksumValue": "75da65603e99837fd3116f1453372efd556f9f97d8de73364594dd78b3c8ec54"
+         }
+       ],
+       "fileName": "Modules/expat/xmltok.c"
+@@ -272,11 +272,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "41b8c8fc275882c76d4210b7d40a18e506b07147"
++          "checksumValue": "705842f8a09b09cc021d82a71ab03344bfd07b0a"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "b2188c7e5fa5b33e355cf6cf342dfb8f6e23859f2a6b1ddf79841d7f84f7b196"
++          "checksumValue": "f95a2b4b7efda40f5faf366537cb20a57dddbad9655859d2e304f5e75f6907cc"
+         }
+       ],
+       "fileName": "Modules/expat/xmltok_ns.c"
+@@ -1548,14 +1548,14 @@
+       "checksums": [
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "461ecc8aa98ab1a68c2db788175665d1a4db640dc05bf0e289b6ea17122144ec"
++          "checksumValue": "9931f9860d18e6cf72d183eb8f309bfb96196c00e1d40caa978e95bc9aa978b6"
+         }
+       ],
+-      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_7_4/expat-2.7.4.tar.gz",
++      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_7_5/expat-2.7.5.tar.gz",
+       "externalRefs": [
+         {
+           "referenceCategory": "SECURITY",
+-          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.7.4:*:*:*:*:*:*:*",
++          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.7.5:*:*:*:*:*:*:*",
+           "referenceType": "cpe23Type"
+         }
+       ],
+@@ -1563,7 +1563,7 @@
+       "name": "expat",
+       "originator": "Organization: Expat development team",
+       "primaryPackagePurpose": "SOURCE",
+-      "versionInfo": "2.7.4"
++      "versionInfo": "2.7.5"
+     },
+     {
+       "SPDXID": "SPDXRef-PACKAGE-hacl-star",
+diff --git a/Modules/expat/expat.h b/Modules/expat/expat.h
+index 6c7c418..18dbaeb 100644
+--- a/Modules/expat/expat.h
++++ b/Modules/expat/expat.h
+@@ -1082,7 +1082,7 @@ XML_SetReparseDeferralEnabled(XML_Parser parser, XML_Bool enabled);
+ */
+ #  define XML_MAJOR_VERSION 2
+ #  define XML_MINOR_VERSION 7
+-#  define XML_MICRO_VERSION 4
++#  define XML_MICRO_VERSION 5
+ 
+ #  ifdef __cplusplus
+ }
+diff --git a/Modules/expat/expat_external.h b/Modules/expat/expat_external.h
+index 6f3f3c4..cf4d445 100644
+--- a/Modules/expat/expat_external.h
++++ b/Modules/expat/expat_external.h
+@@ -12,7 +12,7 @@
+    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2016      Cristian Rodríguez <crrodriguez@opensuse.org>
+-   Copyright (c) 2016-2025 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
+    Licensed under the MIT license:
+diff --git a/Modules/expat/refresh.sh b/Modules/expat/refresh.sh
+index 54d58d0..9e3856b 100755
+--- a/Modules/expat/refresh.sh
++++ b/Modules/expat/refresh.sh
+@@ -12,9 +12,9 @@ fi
+ 
+ # Update this when updating to a new version after verifying that the changes
+ # the update brings in are good. These values are used for verifying the SBOM, too.
+-expected_libexpat_tag="R_2_7_4"
+-expected_libexpat_version="2.7.4"
+-expected_libexpat_sha256="461ecc8aa98ab1a68c2db788175665d1a4db640dc05bf0e289b6ea17122144ec"
++expected_libexpat_tag="R_2_7_5"
++expected_libexpat_version="2.7.5"
++expected_libexpat_sha256="9931f9860d18e6cf72d183eb8f309bfb96196c00e1d40caa978e95bc9aa978b6"
+ 
+ expat_dir="$(realpath "$(dirname -- "${BASH_SOURCE[0]}")")"
+ cd ${expat_dir}
+diff --git a/Modules/expat/xmlparse.c b/Modules/expat/xmlparse.c
+index 086fca5..0248b66 100644
+--- a/Modules/expat/xmlparse.c
++++ b/Modules/expat/xmlparse.c
+@@ -1,4 +1,4 @@
+-/* fab937ab8b186d7d296013669c332e6dfce2f99567882cff1f8eb24223c524a7 (2.7.4+)
++/* 93c1caa66e2b0310459482516af05505b57c5cb7b96df777105308fc585c85d1 (2.7.5+)
+                             __  __            _
+                          ___\ \/ /_ __   __ _| |_
+                         / _ \\  /| '_ \ / _` | __|
+@@ -590,6 +590,8 @@ static XML_Char *poolStoreString(STRING_POOL *pool, const ENCODING *enc,
+ static XML_Bool FASTCALL poolGrow(STRING_POOL *pool);
+ static const XML_Char *FASTCALL poolCopyString(STRING_POOL *pool,
+                                                const XML_Char *s);
++static const XML_Char *FASTCALL poolCopyStringNoFinish(STRING_POOL *pool,
++                                                       const XML_Char *s);
+ static const XML_Char *poolCopyStringN(STRING_POOL *pool, const XML_Char *s,
+                                        int n);
+ static const XML_Char *FASTCALL poolAppendString(STRING_POOL *pool,
+@@ -5086,7 +5088,7 @@ entityValueInitProcessor(XML_Parser parser, const char *s, const char *end,
+     }
+     /* If we get this token, we have the start of what might be a
+        normal tag, but not a declaration (i.e. it doesn't begin with
+-       "<!").  In a DTD context, that isn't legal.
++       "<!" or "<?").  In a DTD context, that isn't legal.
+     */
+     else if (tok == XML_TOK_INSTANCE_START) {
+       *nextPtr = next;
+@@ -5175,6 +5177,15 @@ entityValueProcessor(XML_Parser parser, const char *s, const char *end,
+       /* found end of entity value - can store it now */
+       return storeEntityValue(parser, enc, s, end, XML_ACCOUNT_DIRECT, NULL);
+     }
++    /* If we get this token, we have the start of what might be a
++       normal tag, but not a declaration (i.e. it doesn't begin with
++       "<!" or "<?").  In a DTD context, that isn't legal.
++    */
++    else if (tok == XML_TOK_INSTANCE_START) {
++      *nextPtr = next;
++      return XML_ERROR_SYNTAX;
++    }
++
+     start = next;
+   }
+ }
+@@ -6789,7 +6800,14 @@ storeEntityValue(XML_Parser parser, const ENCODING *enc,
+       return XML_ERROR_NO_MEMORY;
+   }
+ 
+-  const char *next;
++  const char *next = entityTextPtr;
++
++  /* Nothing to tokenize. */
++  if (entityTextPtr >= entityTextEnd) {
++    result = XML_ERROR_NONE;
++    goto endEntityValue;
++  }
++
+   for (;;) {
+     next
+         = entityTextPtr; /* XmlEntityValueTok doesn't always set the last arg */
+@@ -7439,16 +7457,24 @@ setContext(XML_Parser parser, const XML_Char *context) {
+       else {
+         if (! poolAppendChar(&parser->m_tempPool, XML_T('\0')))
+           return XML_FALSE;
+-        prefix
+-            = (PREFIX *)lookup(parser, &dtd->prefixes,
+-                               poolStart(&parser->m_tempPool), sizeof(PREFIX));
+-        if (! prefix)
++        const XML_Char *const prefixName = poolCopyStringNoFinish(
++            &dtd->pool, poolStart(&parser->m_tempPool));
++        if (! prefixName) {
+           return XML_FALSE;
+-        if (prefix->name == poolStart(&parser->m_tempPool)) {
+-          prefix->name = poolCopyString(&dtd->pool, prefix->name);
+-          if (! prefix->name)
+-            return XML_FALSE;
+         }
++
++        prefix = (PREFIX *)lookup(parser, &dtd->prefixes, prefixName,
++                                  sizeof(PREFIX));
++
++        const bool prefixNameUsed = prefix && prefix->name == prefixName;
++        if (prefixNameUsed)
++          poolFinish(&dtd->pool);
++        else
++          poolDiscard(&dtd->pool);
++
++        if (! prefix)
++          return XML_FALSE;
++
+         poolDiscard(&parser->m_tempPool);
+       }
+       for (context = s + 1; *context != CONTEXT_SEP && *context != XML_T('\0');
+@@ -8036,6 +8062,23 @@ poolCopyString(STRING_POOL *pool, const XML_Char *s) {
+   return s;
+ }
+ 
++// A version of `poolCopyString` that does not call `poolFinish`
++// and reverts any partial advancement upon failure.
++static const XML_Char *FASTCALL
++poolCopyStringNoFinish(STRING_POOL *pool, const XML_Char *s) {
++  const XML_Char *const original = s;
++  do {
++    if (! poolAppendChar(pool, *s)) {
++      // Revert any previously successful advancement
++      const ptrdiff_t advancedBy = s - original;
++      if (advancedBy > 0)
++        pool->ptr -= advancedBy;
++      return NULL;
++    }
++  } while (*s++);
++  return pool->start;
++}
++
+ static const XML_Char *
+ poolCopyStringN(STRING_POOL *pool, const XML_Char *s, int n) {
+   if (! pool->ptr && ! poolGrow(pool)) {
+diff --git a/Modules/expat/xmlrole.c b/Modules/expat/xmlrole.c
+index d56bee8..b1dfb45 100644
+--- a/Modules/expat/xmlrole.c
++++ b/Modules/expat/xmlrole.c
+@@ -12,7 +12,7 @@
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
+-   Copyright (c) 2016-2023 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+diff --git a/Modules/expat/xmltok.c b/Modules/expat/xmltok.c
+index 32cd5f1..f6e5f74 100644
+--- a/Modules/expat/xmltok.c
++++ b/Modules/expat/xmltok.c
+@@ -12,7 +12,7 @@
+    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002-2016 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
+-   Copyright (c) 2016-2024 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2016      Pascal Cuoq <cuoq@trust-in-soft.com>
+    Copyright (c) 2016      Don Lewis <truckman@apache.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+diff --git a/Modules/expat/xmltok_ns.c b/Modules/expat/xmltok_ns.c
+index 810ca2c..1cd60de 100644
+--- a/Modules/expat/xmltok_ns.c
++++ b/Modules/expat/xmltok_ns.c
+@@ -11,7 +11,7 @@
+    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+-   Copyright (c) 2017-2021 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
+    Licensed under the MIT license:
+ 

--- a/debian/patches/0037-gh-149017-Upgrade-bundled-Expat-to-2.8.0-GH-149020-G.patch
+++ b/debian/patches/0037-gh-149017-Upgrade-bundled-Expat-to-2.8.0-GH-149020-G.patch
@@ -1,0 +1,833 @@
+From: Stan Ulbrych <stan@python.org>
+Date: Tue, 28 Apr 2026 14:30:12 +0100
+Subject: gh-149017: Upgrade bundled Expat to 2.8.0 (GH-149020) (GH-149073)
+ (cherry picked from commit c181c5fa16273f0cc4d7ed20a016e0921f60fdfd)
+
+Co-authored-by: Stan Ulbrych <stan@python.org>
+(cherry picked from commit 005555a3f0ae20ee8154eb4ee172e1e355144c8c)
+---
+ Misc/sbom.spdx.json            |  36 ++---
+ Modules/expat/expat.h          |  16 ++-
+ Modules/expat/expat_config.h   |   5 +
+ Modules/expat/expat_external.h |   5 +-
+ Modules/expat/internal.h       |   4 +-
+ Modules/expat/refresh.sh       |  18 ++-
+ Modules/expat/xmlparse.c       | 318 +++++++++++++++--------------------------
+ Modules/expat/xmlrole.c        |   2 +-
+ Modules/expat/xmltok.c         |   2 +-
+ Modules/expat/xmltok_ns.c      |   2 +-
+ 10 files changed, 179 insertions(+), 229 deletions(-)
+
+diff --git a/Misc/sbom.spdx.json b/Misc/sbom.spdx.json
+index 5382336..8ff5960 100644
+--- a/Misc/sbom.spdx.json
++++ b/Misc/sbom.spdx.json
+@@ -48,11 +48,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "9dfd09a3be37618cbcea380c2374b2b8f0288f57"
++          "checksumValue": "5343adc95840915b022b1d4524d0acb66b369ba2"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "26805a0d1a7a6a5cd8ead9cf7f4da29f63f0547a9ad41e80dba4ed9fe1943140"
++          "checksumValue": "1ec3bad08b6864c2c479e1fd941038c2dcd24c6d9a16400f4da54912d95aa321"
+         }
+       ],
+       "fileName": "Modules/expat/expat.h"
+@@ -62,11 +62,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "da0328279276800cc747ea7da23886a3f402ccb3"
++          "checksumValue": "d8f9211d52ff0384e229e4d4d56adae5db2d7f91"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "15a80e414e9e7c43edba64b1608a77c724387070138693f9e9bcca49c78a2df7"
++          "checksumValue": "b77f8192baf90aaa41f7023bc68fd1f22ab2552f98758271a1e090544537def5"
+         }
+       ],
+       "fileName": "Modules/expat/expat_external.h"
+@@ -90,11 +90,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "6a4a232233ba1034c3f2b459159d502e9b2d413b"
++          "checksumValue": "2555e70b29c1efc0af40879daafd12f8b36aca2c"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "c803935722f0dbdeeede7f040028fb119135e96dfad949479f8a5304b885bdd6"
++          "checksumValue": "4feb1df53898a48ae0ae04b5d0352c90395c8e693e5c2675f8ced41903d6fa94"
+         }
+       ],
+       "fileName": "Modules/expat/internal.h"
+@@ -174,11 +174,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "0c74fbd48dd515c58eeb65b7e71b29da94be4694"
++          "checksumValue": "cb0af01558ec7b6474d2bd0c9386380c82618e8f"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "861e7a50ce81f9f16b42d32a9caa4f817d962b274b2929b579511c6f76d348d4"
++          "checksumValue": "6745a6b8cdd7344d4bd8f27f605363ed746e57ff02d4ebce3eb1806579cd030f"
+         }
+       ],
+       "fileName": "Modules/expat/xmlparse.c"
+@@ -188,11 +188,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "7cff4d7210f046144f5fa635113f9c26f30fe3d3"
++          "checksumValue": "c8769fcb93f00272a6e6ca560be633649c817ff7"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "eaa6c327f9db4a5cec768d0c01927fea212d3ef4d4f970ebc0a98b9f3602784c"
++          "checksumValue": "5b81f0eb0e144b611dbd1bc9e6037075a16bff94f823d57a81eb2a3e4999e91a"
+         }
+       ],
+       "fileName": "Modules/expat/xmlrole.c"
+@@ -216,11 +216,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "48b7aa6503302d4157c61a8763629f3236c23502"
++          "checksumValue": "63e4766a09e63760c6518670509198f8d638f4ad"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "75da65603e99837fd3116f1453372efd556f9f97d8de73364594dd78b3c8ec54"
++          "checksumValue": "0ad3f915f2748dc91bf4e4b4a50cf40bf2c95769d0eca7e3b293a230d82bb779"
+         }
+       ],
+       "fileName": "Modules/expat/xmltok.c"
+@@ -272,11 +272,11 @@
+       "checksums": [
+         {
+           "algorithm": "SHA1",
+-          "checksumValue": "705842f8a09b09cc021d82a71ab03344bfd07b0a"
++          "checksumValue": "41b8c8fc275882c76d4210b7d40a18e506b07147"
+         },
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "f95a2b4b7efda40f5faf366537cb20a57dddbad9655859d2e304f5e75f6907cc"
++          "checksumValue": "b2188c7e5fa5b33e355cf6cf342dfb8f6e23859f2a6b1ddf79841d7f84f7b196"
+         }
+       ],
+       "fileName": "Modules/expat/xmltok_ns.c"
+@@ -1548,14 +1548,14 @@
+       "checksums": [
+         {
+           "algorithm": "SHA256",
+-          "checksumValue": "9931f9860d18e6cf72d183eb8f309bfb96196c00e1d40caa978e95bc9aa978b6"
++          "checksumValue": "c7cec5f60ea3a42e7780781c6745255c19aa3dbfeeae58646b7132f88dc24780"
+         }
+       ],
+-      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_7_5/expat-2.7.5.tar.gz",
++      "downloadLocation": "https://github.com/libexpat/libexpat/releases/download/R_2_8_0/expat-2.8.0.tar.gz",
+       "externalRefs": [
+         {
+           "referenceCategory": "SECURITY",
+-          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.7.5:*:*:*:*:*:*:*",
++          "referenceLocator": "cpe:2.3:a:libexpat_project:libexpat:2.8.0:*:*:*:*:*:*:*",
+           "referenceType": "cpe23Type"
+         }
+       ],
+@@ -1563,7 +1563,7 @@
+       "name": "expat",
+       "originator": "Organization: Expat development team",
+       "primaryPackagePurpose": "SOURCE",
+-      "versionInfo": "2.7.5"
++      "versionInfo": "2.8.0"
+     },
+     {
+       "SPDXID": "SPDXRef-PACKAGE-hacl-star",
+diff --git a/Modules/expat/expat.h b/Modules/expat/expat.h
+index 18dbaeb..79c609f 100644
+--- a/Modules/expat/expat.h
++++ b/Modules/expat/expat.h
+@@ -45,6 +45,7 @@
+ #ifndef Expat_INCLUDED
+ #  define Expat_INCLUDED 1
+ 
++#  include <stdint.h> // for uint8_t
+ #  include <stdlib.h>
+ #  include "expat_external.h"
+ 
+@@ -917,10 +918,21 @@ XML_SetParamEntityParsing(XML_Parser parser,
+    function behavior. This must be called before parsing is started.
+    Returns 1 if successful, 0 when called after parsing has started.
+    Note: If parser == NULL, the function will do nothing and return 0.
++   DEPRECATED since Expat 2.8.0.
+ */
+ XMLPARSEAPI(int)
+ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt);
+ 
++/* Sets the hash salt to use for internal hash calculations.
++   Helps in preventing DoS attacks based on predicting hash function behavior.
++   This must be called before parsing is started.
++   Returns XML_TRUE if successful, XML_FALSE when called after parsing has
++   started or when parser is NULL.
++   Added in Expat 2.8.0.
++*/
++XMLPARSEAPI(XML_Bool)
++XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]);
++
+ /* If XML_Parse or XML_ParseBuffer have returned XML_STATUS_ERROR, then
+    XML_GetErrorCode returns information about the error.
+ */
+@@ -1081,8 +1093,8 @@ XML_SetReparseDeferralEnabled(XML_Parser parser, XML_Bool enabled);
+    See https://semver.org
+ */
+ #  define XML_MAJOR_VERSION 2
+-#  define XML_MINOR_VERSION 7
+-#  define XML_MICRO_VERSION 5
++#  define XML_MINOR_VERSION 8
++#  define XML_MICRO_VERSION 0
+ 
+ #  ifdef __cplusplus
+ }
+diff --git a/Modules/expat/expat_config.h b/Modules/expat/expat_config.h
+index 09d3161..70df73c 100644
+--- a/Modules/expat/expat_config.h
++++ b/Modules/expat/expat_config.h
+@@ -22,5 +22,10 @@
+ // bpo-30947: Python uses best available entropy sources to
+ // call XML_SetHashSalt(), expat entropy sources are not needed
+ #define XML_POOR_ENTROPY 1
++#undef HAVE_ARC4RANDOM
++#undef HAVE_ARC4RANDOM_BUF
++#undef HAVE_GETENTROPY
++#undef HAVE_GETRANDOM
++#undef HAVE_SYSCALL_GETRANDOM
+ 
+ #endif /* EXPAT_CONFIG_H */
+diff --git a/Modules/expat/expat_external.h b/Modules/expat/expat_external.h
+index cf4d445..cc945c4 100644
+--- a/Modules/expat/expat_external.h
++++ b/Modules/expat/expat_external.h
+@@ -12,9 +12,10 @@
+    Copyright (c) 2001-2002 Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2016      Cristian Rodríguez <crrodriguez@opensuse.org>
+-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2025 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
++   Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
+    Licensed under the MIT license:
+ 
+    Permission is  hereby granted,  free of charge,  to any  person obtaining
+@@ -48,7 +49,7 @@
+ /* Expat tries very hard to make the API boundary very specifically
+    defined.  There are two macros defined to control this boundary;
+    each of these can be defined before including this header to
+-   achieve some different behavior, but doing so it not recommended or
++   achieve some different behavior, but doing so is not recommended or
+    tested frequently.
+ 
+    XMLCALL    - The calling convention to use for all calls across the
+diff --git a/Modules/expat/internal.h b/Modules/expat/internal.h
+index 61266eb..420d421 100644
+--- a/Modules/expat/internal.h
++++ b/Modules/expat/internal.h
+@@ -28,7 +28,7 @@
+    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2003      Greg Stein <gstein@users.sourceforge.net>
+-   Copyright (c) 2016-2025 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
+    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+    Copyright (c) 2023-2024 Sony Corporation / Snild Dolkow <snild@sony.com>
+@@ -113,6 +113,7 @@
+ #if defined(_WIN32)                                                            \
+     && (! defined(__USE_MINGW_ANSI_STDIO)                                      \
+         || (1 - __USE_MINGW_ANSI_STDIO - 1 == 0))
++#  define EXPAT_FMT_LLX(midpart) "%" midpart "I64x"
+ #  define EXPAT_FMT_ULL(midpart) "%" midpart "I64u"
+ #  if defined(_WIN64) // Note: modifiers "td" and "zu" do not work for MinGW
+ #    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "I64d"
+@@ -122,6 +123,7 @@
+ #    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
+ #  endif
+ #else
++#  define EXPAT_FMT_LLX(midpart) "%" midpart "llx"
+ #  define EXPAT_FMT_ULL(midpart) "%" midpart "llu"
+ #  if ! defined(ULONG_MAX)
+ #    error Compiler did not define ULONG_MAX for us
+diff --git a/Modules/expat/refresh.sh b/Modules/expat/refresh.sh
+index 9e3856b..f267023 100755
+--- a/Modules/expat/refresh.sh
++++ b/Modules/expat/refresh.sh
+@@ -12,9 +12,9 @@ fi
+ 
+ # Update this when updating to a new version after verifying that the changes
+ # the update brings in are good. These values are used for verifying the SBOM, too.
+-expected_libexpat_tag="R_2_7_5"
+-expected_libexpat_version="2.7.5"
+-expected_libexpat_sha256="9931f9860d18e6cf72d183eb8f309bfb96196c00e1d40caa978e95bc9aa978b6"
++expected_libexpat_tag="R_2_8_0"
++expected_libexpat_version="2.8.0"
++expected_libexpat_sha256="c7cec5f60ea3a42e7780781c6745255c19aa3dbfeeae58646b7132f88dc24780"
+ 
+ expat_dir="$(realpath "$(dirname -- "${BASH_SOURCE[0]}")")"
+ cd ${expat_dir}
+@@ -57,6 +57,18 @@ rm libexpat.tar.gz
+ # Step 3: Add the namespacing include to expat_external.h
+ sed -i 's/#  define Expat_External_INCLUDED 1/&\n\/* Namespace external symbols to allow multiple libexpat version to\n   co-exist. \*\/\n#include "pyexpatns.h"/' expat_external.h
+ 
++# Step 4: Skip the Windows rand_s entropy path in xmlparse.c when
++# XML_POOR_ENTROPY is set.
++sed -z -i 's|#if defined(_WIN32)\n#  include "random_rand_s\.h"\n#endif /\* defined(_WIN32) \*/|#if defined(_WIN32) \&\& ! defined(XML_POOR_ENTROPY)\n#  include "random_rand_s.h"\n#endif /* defined(_WIN32) \&\& ! defined(XML_POOR_ENTROPY) */|' xmlparse.c
++sed -z -i 's|#  ifdef _WIN32\n  if (writeRandomBytes_rand_s|#  if defined(_WIN32) \&\& ! defined(XML_POOR_ENTROPY)\n  if (writeRandomBytes_rand_s|' xmlparse.c
++
++if ! grep -q '#if defined(_WIN32) && ! defined(XML_POOR_ENTROPY)' xmlparse.c; then
++  echo "
++Error: rand_s gate not patched in xmlparse.c;
++This may be due to source changes and will require updating this script" >&2
++  exit 1
++fi
++
+ echo "
+ Updated! next steps:
+ - Verify all is okay:
+diff --git a/Modules/expat/xmlparse.c b/Modules/expat/xmlparse.c
+index 0248b66..e6842f3 100644
+--- a/Modules/expat/xmlparse.c
++++ b/Modules/expat/xmlparse.c
+@@ -1,4 +1,4 @@
+-/* 93c1caa66e2b0310459482516af05505b57c5cb7b96df777105308fc585c85d1 (2.7.5+)
++/* a5d18f6a50f536615ac1c70304f87d94f99cc85a86b502188952440610ccf0f8 (2.8.0+)
+                             __  __            _
+                          ___\ \/ /_ __   __ _| |_
+                         / _ \\  /| '_ \ / _` | __|
+@@ -41,10 +41,12 @@
+    Copyright (c) 2023-2024 Sony Corporation / Snild Dolkow <snild@sony.com>
+    Copyright (c) 2024-2025 Berkay Eren Ürün <berkay.ueruen@siemens.com>
+    Copyright (c) 2024      Hanno Böck <hanno@gentoo.org>
+-   Copyright (c) 2025      Matthew Fernandez <matthew.fernandez@gmail.com>
++   Copyright (c) 2025-2026 Matthew Fernandez <matthew.fernandez@gmail.com>
+    Copyright (c) 2025      Atrem Borovik <polzovatellllk@gmail.com>
+    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
+    Copyright (c) 2026      Rosen Penev <rosenp@gmail.com>
++   Copyright (c) 2026      Francesco Bertolaccini
++   Copyright (c) 2026      Christian Ng <christianrng@berkeley.edu>
+    Licensed under the MIT license:
+ 
+    Permission is  hereby granted,  free of charge,  to any  person obtaining
+@@ -84,28 +86,16 @@
+ #  error XML_CONTEXT_BYTES must be defined, non-empty and >=0 (0 to disable, >=1 to enable; 1024 is a common default)
+ #endif
+ 
+-#if defined(HAVE_SYSCALL_GETRANDOM)
+-#  if ! defined(_GNU_SOURCE)
+-#    define _GNU_SOURCE 1 /* syscall prototype */
+-#  endif
+-#endif
+-
+-#ifdef _WIN32
+-/* force stdlib to define rand_s() */
+-#  if ! defined(_CRT_RAND_S)
+-#    define _CRT_RAND_S
+-#  endif
+-#endif
+-
+ #include <stdbool.h>
+ #include <stddef.h>
+ #include <string.h> /* memset(), memcpy() */
+ #include <assert.h>
+ #include <limits.h> /* INT_MAX, UINT_MAX */
+ #include <stdio.h>  /* fprintf */
+-#include <stdlib.h> /* getenv, rand_s */
++#include <stdlib.h> /* getenv */
+ #include <stdint.h> /* SIZE_MAX, uintptr_t */
+ #include <math.h>   /* isnan */
++#include <errno.h>
+ 
+ #ifdef _WIN32
+ #  define getpid GetCurrentProcessId
+@@ -125,26 +115,34 @@
+ #include "expat.h"
+ #include "siphash.h"
+ 
++#if defined(HAVE_ARC4RANDOM)
++#  include "random_arc4random.h"
++#endif /* defined(HAVE_ARC4RANDOM) */
++
++#if defined(HAVE_ARC4RANDOM_BUF)
++#  include "random_arc4random_buf.h"
++#endif // defined(HAVE_ARC4RANDOM_BUF)
++
++#if defined(XML_DEV_URANDOM)
++#  include "random_dev_urandom.h"
++#endif /* defined(XML_DEV_URANDOM) */
++
++#if defined(HAVE_GETENTROPY)
++#  include "random_getentropy.h"
++#endif // defined(HAVE_GETENTROPY)
++
+ #if defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
+-#  if defined(HAVE_GETRANDOM)
+-#    include <sys/random.h> /* getrandom */
+-#  else
+-#    include <unistd.h>      /* syscall */
+-#    include <sys/syscall.h> /* SYS_getrandom */
+-#  endif
+-#  if ! defined(GRND_NONBLOCK)
+-#    define GRND_NONBLOCK 0x0001
+-#  endif /* defined(GRND_NONBLOCK) */
+-#endif   /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
++#  include "random_getrandom.h"
++#endif /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
+ 
+-#if defined(_WIN32) && ! defined(LOAD_LIBRARY_SEARCH_SYSTEM32)
+-#  define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
+-#endif
++#if defined(_WIN32) && ! defined(XML_POOR_ENTROPY)
++#  include "random_rand_s.h"
++#endif /* defined(_WIN32) && ! defined(XML_POOR_ENTROPY) */
+ 
+ #if ! defined(HAVE_GETRANDOM) && ! defined(HAVE_SYSCALL_GETRANDOM)             \
+     && ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)            \
+-    && ! defined(XML_DEV_URANDOM) && ! defined(_WIN32)                         \
+-    && ! defined(XML_POOR_ENTROPY)
++    && ! defined(HAVE_GETENTROPY) && ! defined(XML_DEV_URANDOM)                \
++    && ! defined(_WIN32) && ! defined(XML_POOR_ENTROPY)
+ #  error You do not have support for any sources of high quality entropy \
+     enabled.  For end user security, that is probably not what you want. \
+     \
+@@ -153,10 +151,11 @@
+       * Linux >=3.17 + glibc (including <2.25) (syscall SYS_getrandom): HAVE_SYSCALL_GETRANDOM, \
+       * BSD / macOS >=10.7 / glibc >=2.36 (arc4random_buf): HAVE_ARC4RANDOM_BUF, \
+       * BSD / macOS (including <10.7) / glibc >=2.36 (arc4random): HAVE_ARC4RANDOM, \
++      * BSD / macOS >=10.12 / glibc >=2.25 (getentropy): HAVE_GETENTROPY, \
+       * Linux (including <3.17) / BSD / macOS (including <10.7) / Solaris >=8 (/dev/urandom): XML_DEV_URANDOM, \
+       * Windows >=Vista (rand_s): _WIN32. \
+     \
+-    If insist on not using any of these, bypass this error by defining \
++    If you insist on not using any of these, bypass this error by defining \
+     XML_POOR_ENTROPY; you have been warned. \
+     \
+     If you have reasons to patch this detection code away or need changes \
+@@ -604,7 +603,7 @@ static ELEMENT_TYPE *getElementType(XML_Parser parser, const ENCODING *enc,
+ 
+ static XML_Char *copyString(const XML_Char *s, XML_Parser parser);
+ 
+-static unsigned long generate_hash_secret_salt(XML_Parser parser);
++static struct sipkey generate_hash_secret_salt(void);
+ static XML_Bool startParsing(XML_Parser parser);
+ 
+ static XML_Parser parserCreate(const XML_Char *encodingName,
+@@ -777,7 +776,8 @@ struct XML_ParserStruct {
+   XML_Bool m_useForeignDTD;
+   enum XML_ParamEntityParsing m_paramEntityParsing;
+ #endif
+-  unsigned long m_hash_secret_salt;
++  struct sipkey m_hash_secret_salt_128;
++  XML_Bool m_hash_secret_salt_set;
+ #if XML_GE == 1
+   ACCOUNTING m_accounting;
+   MALLOC_TRACKER m_alloc_tracker;
+@@ -1036,135 +1036,6 @@ static const XML_Char implicitContext[]
+        ASCII_s,     ASCII_p,     ASCII_a,      ASCII_c,      ASCII_e,
+        '\0'};
+ 
+-/* To avoid warnings about unused functions: */
+-#if ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)
+-
+-#  if defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
+-
+-/* Obtain entropy on Linux 3.17+ */
+-static int
+-writeRandomBytes_getrandom_nonblock(void *target, size_t count) {
+-  int success = 0; /* full count bytes written? */
+-  size_t bytesWrittenTotal = 0;
+-  const unsigned int getrandomFlags = GRND_NONBLOCK;
+-
+-  do {
+-    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
+-    const size_t bytesToWrite = count - bytesWrittenTotal;
+-
+-    assert(bytesToWrite <= INT_MAX);
+-
+-    const int bytesWrittenMore =
+-#    if defined(HAVE_GETRANDOM)
+-        (int)getrandom(currentTarget, bytesToWrite, getrandomFlags);
+-#    else
+-        (int)syscall(SYS_getrandom, currentTarget, bytesToWrite,
+-                     getrandomFlags);
+-#    endif
+-
+-    if (bytesWrittenMore > 0) {
+-      bytesWrittenTotal += bytesWrittenMore;
+-      if (bytesWrittenTotal >= count)
+-        success = 1;
+-    }
+-  } while (! success && (errno == EINTR));
+-
+-  return success;
+-}
+-
+-#  endif /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
+-
+-#  if ! defined(_WIN32) && defined(XML_DEV_URANDOM)
+-
+-/* Extract entropy from /dev/urandom */
+-static int
+-writeRandomBytes_dev_urandom(void *target, size_t count) {
+-  int success = 0; /* full count bytes written? */
+-  size_t bytesWrittenTotal = 0;
+-
+-  const int fd = open("/dev/urandom", O_RDONLY);
+-  if (fd < 0) {
+-    return 0;
+-  }
+-
+-  do {
+-    void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
+-    const size_t bytesToWrite = count - bytesWrittenTotal;
+-
+-    const ssize_t bytesWrittenMore = read(fd, currentTarget, bytesToWrite);
+-
+-    if (bytesWrittenMore > 0) {
+-      bytesWrittenTotal += bytesWrittenMore;
+-      if (bytesWrittenTotal >= count)
+-        success = 1;
+-    }
+-  } while (! success && (errno == EINTR));
+-
+-  close(fd);
+-  return success;
+-}
+-
+-#  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
+-
+-#endif /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
+-
+-#if defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF)
+-
+-static void
+-writeRandomBytes_arc4random(void *target, size_t count) {
+-  size_t bytesWrittenTotal = 0;
+-
+-  while (bytesWrittenTotal < count) {
+-    const uint32_t random32 = arc4random();
+-    size_t i = 0;
+-
+-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
+-         i++, bytesWrittenTotal++) {
+-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
+-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
+-    }
+-  }
+-}
+-
+-#endif /* defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF) */
+-
+-#ifdef _WIN32
+-
+-/* Provide declaration of rand_s() for MinGW-32 (not 64, which has it),
+-   as it didn't declare it in its header prior to version 5.3.0 of its
+-   runtime package (mingwrt, containing stdlib.h).  The upstream fix
+-   was introduced at https://osdn.net/projects/mingw/ticket/39658 . */
+-#  if defined(__MINGW32__) && defined(__MINGW32_VERSION)                       \
+-      && __MINGW32_VERSION < 5003000L && ! defined(__MINGW64_VERSION_MAJOR)
+-__declspec(dllimport) int rand_s(unsigned int *);
+-#  endif
+-
+-/* Obtain entropy on Windows using the rand_s() function which
+- * generates cryptographically secure random numbers.  Internally it
+- * uses RtlGenRandom API which is present in Windows XP and later.
+- */
+-static int
+-writeRandomBytes_rand_s(void *target, size_t count) {
+-  size_t bytesWrittenTotal = 0;
+-
+-  while (bytesWrittenTotal < count) {
+-    unsigned int random32 = 0;
+-    size_t i = 0;
+-
+-    if (rand_s(&random32))
+-      return 0; /* failure */
+-
+-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
+-         i++, bytesWrittenTotal++) {
+-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
+-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
+-    }
+-  }
+-  return 1; /* success */
+-}
+-
+-#endif /* _WIN32 */
+-
+ #if ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM)
+ 
+ static unsigned long
+@@ -1192,69 +1063,70 @@ gather_time_entropy(void) {
+ 
+ #endif /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
+ 
+-static unsigned long
+-ENTROPY_DEBUG(const char *label, unsigned long entropy) {
++static struct sipkey
++ENTROPY_DEBUG(const char *label, struct sipkey entropy_128) {
+   if (getDebugLevel("EXPAT_ENTROPY_DEBUG", 0) >= 1u) {
+-    fprintf(stderr, "expat: Entropy: %s --> 0x%0*lx (%lu bytes)\n", label,
+-            (int)sizeof(entropy) * 2, entropy, (unsigned long)sizeof(entropy));
++    fprintf(stderr,
++            "expat: Entropy: %s --> [0x" EXPAT_FMT_LLX(
++                "016") ", 0x" EXPAT_FMT_LLX("016") "] (16 bytes)\n",
++            label, (unsigned long long)entropy_128.k[0],
++            (unsigned long long)entropy_128.k[1]);
+   }
+-  return entropy;
++  return entropy_128;
+ }
+ 
+-static unsigned long
+-generate_hash_secret_salt(XML_Parser parser) {
+-  unsigned long entropy;
+-  (void)parser;
++static struct sipkey
++generate_hash_secret_salt(void) {
++  struct sipkey entropy;
+ 
+   /* "Failproof" high quality providers: */
+ #if defined(HAVE_ARC4RANDOM_BUF)
+-  arc4random_buf(&entropy, sizeof(entropy));
++  writeRandomBytes_arc4random_buf(&entropy, sizeof(entropy));
+   return ENTROPY_DEBUG("arc4random_buf", entropy);
+ #elif defined(HAVE_ARC4RANDOM)
+-  writeRandomBytes_arc4random((void *)&entropy, sizeof(entropy));
++  writeRandomBytes_arc4random(&entropy, sizeof(entropy));
+   return ENTROPY_DEBUG("arc4random", entropy);
+ #else
+   /* Try high quality providers first .. */
+-#  ifdef _WIN32
+-  if (writeRandomBytes_rand_s((void *)&entropy, sizeof(entropy))) {
++#  if defined(_WIN32) && ! defined(XML_POOR_ENTROPY)
++  if (writeRandomBytes_rand_s(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("rand_s", entropy);
+   }
++#  elif defined(HAVE_GETENTROPY)
++  if (writeRandomBytes_getentropy(&entropy, sizeof(entropy))) {
++    return ENTROPY_DEBUG("getentropy", entropy);
++  }
++  errno = 0;
+ #  elif defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM)
+-  if (writeRandomBytes_getrandom_nonblock((void *)&entropy, sizeof(entropy))) {
++  if (writeRandomBytes_getrandom_nonblock(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("getrandom", entropy);
+   }
+ #  endif
+ #  if ! defined(_WIN32) && defined(XML_DEV_URANDOM)
+-  if (writeRandomBytes_dev_urandom((void *)&entropy, sizeof(entropy))) {
++  if (writeRandomBytes_dev_urandom(&entropy, sizeof(entropy))) {
+     return ENTROPY_DEBUG("/dev/urandom", entropy);
+   }
+ #  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
+   /* .. and self-made low quality for backup: */
+ 
+-  entropy = gather_time_entropy();
++  entropy.k[0] = 0;
++  entropy.k[1] = gather_time_entropy();
+ #  if ! defined(__wasi__)
+   /* Process ID is 0 bits entropy if attacker has local access */
+-  entropy ^= getpid();
++  entropy.k[1] ^= getpid();
+ #  endif
+ 
+   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
+   if (sizeof(unsigned long) == 4) {
+-    return ENTROPY_DEBUG("fallback(4)", entropy * 2147483647);
++    entropy.k[1] *= 2147483647;
++    return ENTROPY_DEBUG("fallback(4)", entropy);
+   } else {
+-    return ENTROPY_DEBUG("fallback(8)",
+-                         entropy * (unsigned long)2305843009213693951ULL);
++    entropy.k[1] *= 2305843009213693951ULL;
++    return ENTROPY_DEBUG("fallback(8)", entropy);
+   }
+ #endif
+ }
+ 
+-static unsigned long
+-get_hash_secret_salt(XML_Parser parser) {
+-  const XML_Parser rootParser = getRootParserOf(parser, NULL);
+-  assert(! rootParser->m_parentParser);
+-
+-  return rootParser->m_hash_secret_salt;
+-}
+-
+ static enum XML_Error
+ callProcessor(XML_Parser parser, const char *start, const char *end,
+               const char **endPtr) {
+@@ -1323,8 +1195,10 @@ callProcessor(XML_Parser parser, const char *start, const char *end,
+ static XML_Bool /* only valid for root parser */
+ startParsing(XML_Parser parser) {
+   /* hash functions must be initialized before setContext() is called */
+-  if (parser->m_hash_secret_salt == 0)
+-    parser->m_hash_secret_salt = generate_hash_secret_salt(parser);
++  if (parser->m_hash_secret_salt_set != XML_TRUE) {
++    parser->m_hash_secret_salt_128 = generate_hash_secret_salt();
++    parser->m_hash_secret_salt_set = XML_TRUE;
++  }
+   if (parser->m_ns) {
+     /* implicit context only set for root parser, since child
+        parsers (i.e. external entity parsers) will inherit it
+@@ -1612,7 +1486,9 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
+   parser->m_useForeignDTD = XML_FALSE;
+   parser->m_paramEntityParsing = XML_PARAM_ENTITY_PARSING_NEVER;
+ #endif
+-  parser->m_hash_secret_salt = 0;
++  parser->m_hash_secret_salt_128.k[0] = 0;
++  parser->m_hash_secret_salt_128.k[1] = 0;
++  parser->m_hash_secret_salt_set = XML_FALSE;
+ 
+ #if XML_GE == 1
+   memset(&parser->m_accounting, 0, sizeof(ACCOUNTING));
+@@ -1779,7 +1655,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+      from hash tables associated with either parser without us having
+      to worry which hash secrets each table has.
+   */
+-  unsigned long oldhash_secret_salt;
++  struct sipkey oldhash_secret_salt_128;
++  XML_Bool oldhash_secret_salt_set;
+   XML_Bool oldReparseDeferralEnabled;
+ 
+   /* Validate the oldParser parameter before we pull everything out of it */
+@@ -1825,7 +1702,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+      from hash tables associated with either parser without us having
+      to worry which hash secrets each table has.
+   */
+-  oldhash_secret_salt = parser->m_hash_secret_salt;
++  oldhash_secret_salt_128 = parser->m_hash_secret_salt_128;
++  oldhash_secret_salt_set = parser->m_hash_secret_salt_set;
+   oldReparseDeferralEnabled = parser->m_reparseDeferralEnabled;
+ 
+ #ifdef XML_DTD
+@@ -1880,7 +1758,8 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
+     parser->m_externalEntityRefHandlerArg = oldExternalEntityRefHandlerArg;
+   parser->m_defaultExpandInternalEntities = oldDefaultExpandInternalEntities;
+   parser->m_ns_triplets = oldns_triplets;
+-  parser->m_hash_secret_salt = oldhash_secret_salt;
++  parser->m_hash_secret_salt_128 = oldhash_secret_salt_128;
++  parser->m_hash_secret_salt_set = oldhash_secret_salt_set;
+   parser->m_reparseDeferralEnabled = oldReparseDeferralEnabled;
+   parser->m_parentParser = oldParser;
+ #ifdef XML_DTD
+@@ -2324,6 +2203,7 @@ XML_SetParamEntityParsing(XML_Parser parser,
+ #endif
+ }
+ 
++// DEPRECATED since Expat 2.8.0.
+ int XMLCALL
+ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
+   if (parser == NULL)
+@@ -2335,10 +2215,46 @@ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
+   /* block after XML_Parse()/XML_ParseBuffer() has been called */
+   if (parserBusy(rootParser))
+     return 0;
+-  rootParser->m_hash_secret_salt = hash_salt;
++
++  rootParser->m_hash_secret_salt_128.k[0] = 0;
++  rootParser->m_hash_secret_salt_128.k[1] = hash_salt;
++
++  if (hash_salt != 0) { // to remain backwards compatible
++    rootParser->m_hash_secret_salt_set = XML_TRUE;
++
++    if (sizeof(unsigned long) == 4)
++      ENTROPY_DEBUG("explicit(4)", rootParser->m_hash_secret_salt_128);
++    else
++      ENTROPY_DEBUG("explicit(8)", rootParser->m_hash_secret_salt_128);
++  }
++
+   return 1;
+ }
+ 
++XML_Bool XMLCALL
++XML_SetHashSalt16Bytes(XML_Parser parser, const uint8_t entropy[16]) {
++  if (parser == NULL)
++    return XML_FALSE;
++
++  if (entropy == NULL)
++    return XML_FALSE;
++
++  const XML_Parser rootParser = getRootParserOf(parser, NULL);
++  assert(! rootParser->m_parentParser);
++
++  /* block after XML_Parse()/XML_ParseBuffer() has been called */
++  if (parserBusy(rootParser))
++    return XML_FALSE;
++
++  sip_tokey(&(rootParser->m_hash_secret_salt_128), entropy);
++
++  rootParser->m_hash_secret_salt_set = XML_TRUE;
++
++  ENTROPY_DEBUG("explicit(16)", rootParser->m_hash_secret_salt_128);
++
++  return XML_TRUE;
++}
++
+ enum XML_Status XMLCALL
+ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
+   if ((parser == NULL) || (len < 0) || ((s == NULL) && (len != 0))) {
+@@ -7842,8 +7758,10 @@ keylen(KEY s) {
+ 
+ static void
+ copy_salt_to_sipkey(XML_Parser parser, struct sipkey *key) {
+-  key->k[0] = 0;
+-  key->k[1] = get_hash_secret_salt(parser);
++  const XML_Parser rootParser = getRootParserOf(parser, NULL);
++  assert(! rootParser->m_parentParser);
++
++  *key = rootParser->m_hash_secret_salt_128;
+ }
+ 
+ static unsigned long FASTCALL
+diff --git a/Modules/expat/xmlrole.c b/Modules/expat/xmlrole.c
+index b1dfb45..d56bee8 100644
+--- a/Modules/expat/xmlrole.c
++++ b/Modules/expat/xmlrole.c
+@@ -12,7 +12,7 @@
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2002-2003 Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
+-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2023 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+diff --git a/Modules/expat/xmltok.c b/Modules/expat/xmltok.c
+index f6e5f74..32cd5f1 100644
+--- a/Modules/expat/xmltok.c
++++ b/Modules/expat/xmltok.c
+@@ -12,7 +12,7 @@
+    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002-2016 Karl Waclawek <karl@waclawek.net>
+    Copyright (c) 2005-2009 Steven Solie <steven@solie.ca>
+-   Copyright (c) 2016-2026 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2016-2024 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2016      Pascal Cuoq <cuoq@trust-in-soft.com>
+    Copyright (c) 2016      Don Lewis <truckman@apache.org>
+    Copyright (c) 2017      Rhodri James <rhodri@wildebeest.org.uk>
+diff --git a/Modules/expat/xmltok_ns.c b/Modules/expat/xmltok_ns.c
+index 1cd60de..810ca2c 100644
+--- a/Modules/expat/xmltok_ns.c
++++ b/Modules/expat/xmltok_ns.c
+@@ -11,7 +11,7 @@
+    Copyright (c) 2002      Greg Stein <gstein@users.sourceforge.net>
+    Copyright (c) 2002      Fred L. Drake, Jr. <fdrake@users.sourceforge.net>
+    Copyright (c) 2002-2006 Karl Waclawek <karl@waclawek.net>
+-   Copyright (c) 2017-2026 Sebastian Pipping <sebastian@pipping.org>
++   Copyright (c) 2017-2021 Sebastian Pipping <sebastian@pipping.org>
+    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
+    Licensed under the MIT license:
+ 

--- a/debian/patches/0038-gh-149486-tarfile.data_filter-validate-written-link-.patch
+++ b/debian/patches/0038-gh-149486-tarfile.data_filter-validate-written-link-.patch
@@ -1,0 +1,160 @@
+From: Petr Viktorin <encukou@gmail.com>
+Date: Fri, 8 May 2026 14:16:06 +0200
+Subject: gh-149486: tarfile.data_filter: validate written link target
+ (GH-149487)
+
+The data filter rewrote linknames with normpath() but ran the
+containment check against the un-normalised value, and computed a
+symlink's directory before stripping trailing slashes.  Both let a
+crafted archive create links pointing outside the destination.  Also
+reject link members that resolve to the destination directory itself,
+which could otherwise replace it with a symlink and redirect all
+subsequent members.
+
+(Patch by Greg; Petr's just reviewing & merging.)
+(cherry picked from commit 578411982c16f753f4893532510099ef665117da)
+
+Co-authored-by: Petr Viktorin <encukou@gmail.com>
+Co-authored-by: Gregory P. Smith <greg@krypto.org>
+---
+ Lib/tarfile.py           | 16 ++++++---
+ Lib/test/test_tarfile.py | 87 +++++++++++++++++++++++++++++++++++++++++++++---
+ 2 files changed, 94 insertions(+), 9 deletions(-)
+
+diff --git a/Lib/tarfile.py b/Lib/tarfile.py
+index 59d3f6e..fcb1040 100755
+--- a/Lib/tarfile.py
++++ b/Lib/tarfile.py
+@@ -816,16 +816,22 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
+         if member.islnk() or member.issym():
+             if os.path.isabs(member.linkname):
+                 raise AbsoluteLinkError(member)
++            # A link member that resolves to the destination directory itself
++            # would replace it with a (sym)link, redirecting the destination
++            # for all subsequent members.
++            if target_path == dest_path:
++                raise OutsideDestinationError(member, target_path)
+             normalized = os.path.normpath(member.linkname)
+             if normalized != member.linkname:
+                 new_attrs['linkname'] = normalized
+             if member.issym():
+-                target_path = os.path.join(dest_path,
+-                                           os.path.dirname(name),
+-                                           member.linkname)
++                # The symlink is created at `name` with trailing separators
++                # stripped, so its target is relative to the directory
++                # containing that path.
++                link_dir = os.path.dirname(name.rstrip('/' + os.sep))
++                target_path = os.path.join(dest_path, link_dir, normalized)
+             else:
+-                target_path = os.path.join(dest_path,
+-                                           member.linkname)
++                target_path = os.path.join(dest_path, normalized)
+             target_path = os.path.realpath(target_path,
+                                            strict=os.path.ALLOW_MISSING)
+             if os.path.commonpath([target_path, dest_path]) != dest_path:
+diff --git a/Lib/test/test_tarfile.py b/Lib/test/test_tarfile.py
+index 759fa03..fefae4b 100644
+--- a/Lib/test/test_tarfile.py
++++ b/Lib/test/test_tarfile.py
+@@ -3701,10 +3701,19 @@ class TestExtractionFilters(unittest.TestCase):
+                     + "which is outside the destination")
+ 
+             with self.check_context(arc.open(), 'data'):
+-                self.expect_exception(
+-                    tarfile.LinkOutsideDestinationError,
+-                    """'parent' would link to ['"].*outerdir['"], """
+-                    + "which is outside the destination")
++                if self.dotdot_resolves_early:
++                    # 'current/../..' normalises to '..', which is rejected.
++                    self.expect_exception(
++                        tarfile.LinkOutsideDestinationError,
++                        """'parent' would link to ['"].*outerdir['"], """
++                        + "which is outside the destination")
++                else:
++                    # 'current/..' normalises to '.'; the rewritten link is
++                    # created and 'parent/evil' lands harmlessly inside the
++                    # destination.
++                    self.expect_file('current', symlink_to='.')
++                    self.expect_file('parent', symlink_to='.')
++                    self.expect_file('evil')
+ 
+         else:
+             # No symlink support. The symlinks are ignored.
+@@ -3978,6 +3987,76 @@ class TestExtractionFilters(unittest.TestCase):
+                     + """['"].*moo['"], which is outside the """
+                     + "destination")
+ 
++    @symlink_test
++    @os_helper.skip_unless_symlink
++    def test_normpath_realpath_mismatch(self):
++        # The link-target check must validate the value that will actually
++        # be written to disk (the normalised linkname), not the original.
++        # Here 'a' is a symlink to a deep nonexistent path, so realpath()
++        # of 'a/../../...' stays inside the destination while normpath()
++        # collapses 'a/..' lexically and escapes.
++        depth = len(self.destdir.parts) + 5
++        deep = '/'.join(f'p{i}' for i in range(depth))
++        sneaky = 'a/' + '../' * depth + 'flag'
++        for kind in 'symlink_to', 'hardlink_to':
++            with self.subTest(kind):
++                with ArchiveMaker() as arc:
++                    arc.add('a', symlink_to=deep)
++                    arc.add('escape', **{kind: sneaky})
++                with self.check_context(arc.open(), 'data'):
++                    self.expect_exception(
++                        tarfile.LinkOutsideDestinationError)
++
++    @symlink_test
++    @os_helper.skip_unless_symlink
++    def test_symlink_trailing_slash(self):
++        # A trailing slash on a symlink member's name must not cause the
++        # link target to be resolved relative to the wrong directory.
++        with ArchiveMaker() as arc:
++            t = tarfile.TarInfo('x/')
++            t.type = tarfile.SYMTYPE
++            t.linkname = '..'
++            arc.tar_w.addfile(t)
++            arc.add('x/escaped', content='hi')
++
++        with self.check_context(arc.open(), 'data'):
++            self.expect_exception(tarfile.LinkOutsideDestinationError)
++
++    @symlink_test
++    @os_helper.skip_unless_symlink
++    def test_link_at_destination(self):
++        # A link member whose name resolves to the destination directory
++        # itself must be rejected: otherwise the destination is replaced
++        # by a symlink and later members can be redirected through it.
++        for name in '', '.', './':
++            with ArchiveMaker() as arc:
++                t = tarfile.TarInfo(name)
++                t.type = tarfile.SYMTYPE
++                t.linkname = '.'
++                arc.tar_w.addfile(t)
++
++            with self.check_context(arc.open(), 'data'):
++                self.expect_exception(tarfile.OutsideDestinationError)
++
++    @symlink_test
++    @os_helper.skip_unless_symlink
++    def test_empty_name_symlink_chain(self):
++        # Regression test for a chain of empty-named symlinks that
++        # incrementally redirects the destination outwards.
++        with ArchiveMaker() as arc:
++            for name, target in [('', ''), ('a/', '..'),
++                                 ('', 'dummy'), ('', 'a'),
++                                 ('b/', '..'),
++                                 ('', 'dummy'), ('', 'a/b')]:
++                t = tarfile.TarInfo(name)
++                t.type = tarfile.SYMTYPE
++                t.linkname = target
++                arc.tar_w.addfile(t)
++            arc.add('escaped', content='hi')
++
++        with self.check_context(arc.open(), 'data'):
++            self.expect_exception(tarfile.FilterError)
++
+     @symlink_test
+     def test_deep_symlink(self):
+         # Test that symlinks and hardlinks inside a directory

--- a/debian/patches/0039-Move-dotdot_resolves_early-setting-to-setUpClass.patch
+++ b/debian/patches/0039-Move-dotdot_resolves_early-setting-to-setUpClass.patch
@@ -1,0 +1,97 @@
+From: Petr Viktorin <encukou@gmail.com>
+Date: Fri, 8 May 2026 17:21:34 +0200
+Subject: Move dotdot_resolves_early setting to setUpClass
+
+---
+ Lib/test/test_tarfile.py | 64 +++++++++++++++++++++++++-----------------------
+ 1 file changed, 34 insertions(+), 30 deletions(-)
+
+diff --git a/Lib/test/test_tarfile.py b/Lib/test/test_tarfile.py
+index fefae4b..faf0fbe 100644
+--- a/Lib/test/test_tarfile.py
++++ b/Lib/test/test_tarfile.py
+@@ -3530,6 +3530,39 @@ class TestExtractionFilters(unittest.TestCase):
+     # The destination for the extraction, within `outerdir`
+     destdir = outerdir / 'dest'
+ 
++    @classmethod
++    def setUpClass(cls):
++        # Posix and Windows have different pathname resolution:
++        # either symlink or a '..' component resolve first.
++        # Let's see which we are on.
++        if os_helper.can_symlink():
++            testpath = os.path.join(TEMPDIR, 'resolution_test')
++            os.mkdir(testpath)
++
++            # testpath/current links to `.` which is all of:
++            #   - `testpath`
++            #   - `testpath/current`
++            #   - `testpath/current/current`
++            #   - etc.
++            os.symlink('.', os.path.join(testpath, 'current'))
++
++            # we'll test where `testpath/current/../file` ends up
++            with open(os.path.join(testpath, 'current', '..', 'file'), 'w'):
++                pass
++
++            if os.path.exists(os.path.join(testpath, 'file')):
++                # Windows collapses 'current\..' to '.' first, leaving
++                # 'testpath\file'
++                cls.dotdot_resolves_early = True
++            elif os.path.exists(os.path.join(testpath, '..', 'file')):
++                # Posix resolves 'current' to '.' first, leaving
++                # 'testpath/../file'
++                cls.dotdot_resolves_early = False
++            else:
++                raise AssertionError('Could not determine link resolution')
++        else:
++            cls.dotdot_resolves_early = False
++
+     @contextmanager
+     def check_context(self, tar, filter, *, check_flag=True):
+         """Extracts `tar` to `self.destdir` and allows checking the result
+@@ -3803,35 +3836,6 @@ class TestExtractionFilters(unittest.TestCase):
+         # Test interplaying symlinks
+         # Inspired by 'dirsymlink2b' in jwilk/traversal-archives
+ 
+-        # Posix and Windows have different pathname resolution:
+-        # either symlink or a '..' component resolve first.
+-        # Let's see which we are on.
+-        if os_helper.can_symlink():
+-            testpath = os.path.join(TEMPDIR, 'resolution_test')
+-            os.mkdir(testpath)
+-
+-            # testpath/current links to `.` which is all of:
+-            #   - `testpath`
+-            #   - `testpath/current`
+-            #   - `testpath/current/current`
+-            #   - etc.
+-            os.symlink('.', os.path.join(testpath, 'current'))
+-
+-            # we'll test where `testpath/current/../file` ends up
+-            with open(os.path.join(testpath, 'current', '..', 'file'), 'w'):
+-                pass
+-
+-            if os.path.exists(os.path.join(testpath, 'file')):
+-                # Windows collapses 'current\..' to '.' first, leaving
+-                # 'testpath\file'
+-                dotdot_resolves_early = True
+-            elif os.path.exists(os.path.join(testpath, '..', 'file')):
+-                # Posix resolves 'current' to '.' first, leaving
+-                # 'testpath/../file'
+-                dotdot_resolves_early = False
+-            else:
+-                raise AssertionError('Could not determine link resolution')
+-
+         with ArchiveMaker() as arc:
+ 
+             # `current` links to `.` which is both the destination directory
+@@ -3867,7 +3871,7 @@ class TestExtractionFilters(unittest.TestCase):
+ 
+         with self.check_context(arc.open(), 'data'):
+             if os_helper.can_symlink():
+-                if dotdot_resolves_early:
++                if self.dotdot_resolves_early:
+                     # Fail when extracting a file outside destination
+                     self.expect_exception(
+                             tarfile.OutsideDestinationError,

--- a/debian/patches/0040-gh-87451-Apply-CVE-2021-4189-PASV-fix-to-ftplib.ftpc.patch
+++ b/debian/patches/0040-gh-87451-Apply-CVE-2021-4189-PASV-fix-to-ftplib.ftpc.patch
@@ -1,0 +1,98 @@
+From: "Gregory P. Smith" <68491+gpshead@users.noreply.github.com>
+Date: Wed, 13 May 2026 10:33:43 -0700
+Subject: gh-87451: Apply CVE-2021-4189 PASV fix to ftplib.ftpcp() (GH-149648)
+
+ftpcp() called parse227() directly and passed the source server's
+self-reported PASV IPv4 address to the target server's PORT command,
+bypassing the CVE-2021-4189 fix that was applied only to FTP.makepasv().
+A malicious source FTP server could use this to redirect the target
+server's data connection to an arbitrary host:port (SSRF).
+
+ftpcp() now uses the source server's actual peer address, honoring the
+existing trust_server_pasv_ipv4_address opt-out, the same as makepasv().
+
+Thanks to Qi Ding at Aurascape AI for the report. (GHSA-w8c5-q2xf-gf7c)
+(cherry picked from commit eac4fe3b2c77693790a5ef7dfab127c1fee81bf9)
+
+Co-authored-by: Gregory P. Smith <68491+gpshead@users.noreply.github.com>
+---
+ Lib/ftplib.py           | 11 ++++++++++-
+ Lib/test/test_ftplib.py | 36 +++++++++++++++++++++++++++++++++++-
+ 2 files changed, 45 insertions(+), 2 deletions(-)
+
+diff --git a/Lib/ftplib.py b/Lib/ftplib.py
+index 10c5d1e..463da58 100644
+--- a/Lib/ftplib.py
++++ b/Lib/ftplib.py
+@@ -883,7 +883,16 @@ def ftpcp(source, sourcename, target, targetname = '', type = 'I'):
+     type = 'TYPE ' + type
+     source.voidcmd(type)
+     target.voidcmd(type)
+-    sourcehost, sourceport = parse227(source.sendcmd('PASV'))
++    # Don't trust the IPv4 address the source server advertises in its PASV
++    # reply: a malicious source could otherwise point the target's data
++    # connection at an arbitrary host (SSRF).  A caller that needs the old
++    # behavior can set trust_server_pasv_ipv4_address on the source FTP
++    # object.  See FTP.makepasv(), which applies the same rule.
++    untrusted_host, sourceport = parse227(source.sendcmd('PASV'))
++    if source.trust_server_pasv_ipv4_address:
++        sourcehost = untrusted_host
++    else:
++        sourcehost = source.sock.getpeername()[0]
+     target.sendport(sourcehost, sourceport)
+     # RFC 959: the user must "listen" [...] BEFORE sending the
+     # transfer request.
+diff --git a/Lib/test/test_ftplib.py b/Lib/test/test_ftplib.py
+index 204a77d..7542f01 100644
+--- a/Lib/test/test_ftplib.py
++++ b/Lib/test/test_ftplib.py
+@@ -16,7 +16,7 @@ try:
+ except ImportError:
+     ssl = None
+ 
+-from unittest import TestCase, skipUnless
++from unittest import mock, TestCase, skipUnless
+ from test import support
+ from test.support import threading_helper
+ from test.support import socket_helper
+@@ -1142,6 +1142,40 @@ class TestTimeouts(TestCase):
+         ftp.close()
+ 
+ 
++class TestFtpcpSecurity(TestCase):
++    """ftpcp() must not trust the host a source server advertises in PASV.
++
++    A malicious source server can otherwise redirect the target server's
++    data connection to an arbitrary host:port (SSRF), so ftpcp() uses the
++    source server's actual peer address instead, the same as FTP.makepasv().
++    """
++
++    def _make_pair(self, *, advertised_host, real_host, trust=False):
++        source = mock.Mock(spec=ftplib.FTP)
++        source.trust_server_pasv_ipv4_address = trust
++        source.sock.getpeername.return_value = (real_host, 21)
++        # PASV replies give the host as comma-separated octets, not dotted.
++        advertised = advertised_host.replace('.', ',')
++        source.sendcmd.side_effect = lambda cmd: (
++            f'227 Entering Passive Mode ({advertised},1,2).'
++            if cmd == 'PASV' else '150 ok')
++        target = mock.Mock(spec=ftplib.FTP)
++        target.sendcmd.return_value = '150 ok'
++        return source, target
++
++    def test_ftpcp_ignores_untrusted_pasv_host(self):
++        source, target = self._make_pair(advertised_host='10.0.0.5',
++                                         real_host='198.51.100.7')
++        ftplib.ftpcp(source, 'a', target, 'b')
++        target.sendport.assert_called_once_with('198.51.100.7', 258)
++
++    def test_ftpcp_trust_server_pasv_ipv4_address(self):
++        source, target = self._make_pair(advertised_host='10.0.0.5',
++                                         real_host='198.51.100.7', trust=True)
++        ftplib.ftpcp(source, 'a', target, 'b')
++        target.sendport.assert_called_once_with('10.0.0.5', 258)
++
++
+ class MiscTestCase(TestCase):
+     def test__all__(self):
+         not_exported = {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -38,3 +38,9 @@ Add-Debian-specific-documentation-path-to-IDLE-menu.diff
 Remove-Docutils-list-monkeypatch.patch
 0033-gh-143930-Reject-leading-dashes-in-webbrowser-URLs-G.patch
 0034-gh-143930-Tweak-the-exception-message-and-increase-t.patch
+0035-gh-146211-Reject-CR-LF-in-HTTP-tunnel-request-header.patch
+0036-gh-146083-Upgrade-bundled-Expat-to-2.7.5-GH-146085-c.patch
+0037-gh-149017-Upgrade-bundled-Expat-to-2.8.0-GH-149020-G.patch
+0038-gh-149486-tarfile.data_filter-validate-written-link-.patch
+0039-Move-dotdot_resolves_early-setting-to-setUpClass.patch
+0040-gh-87451-Apply-CVE-2021-4189-PASV-fix-to-ftplib.ftpc.patch


### PR DESCRIPTION
- gh-146211: Reject CR/LF in HTTP tunnel request headers (GH-146212) (cherry picked from commit 05ed7ce7ae9e17c23a04085b2539fe6d6d3cef69)
- gh-146083: Upgrade bundled Expat to 2.7.5 (GH-146085) (cherry picked from commit e39d84a37dfc8bcdc0eb4d6f3ce7d5ee829d7f30)
- gh-149017: Upgrade bundled Expat to 2.8.0 (GH-149020) (GH-149073) (cherry picked from commit c181c5fa16273f0cc4d7ed20a016e0921f60fdfd)
- gh-149486: tarfile.data_filter: validate written link target (GH-149487)
- Move dotdot_resolves_early setting to setUpClass
- gh-87451: Apply CVE-2021-4189 PASV fix to ftplib.ftpcp() (GH-149648)
